### PR TITLE
Remove double quotes from base64 token before decoding

### DIFF
--- a/src/redemption.ts
+++ b/src/redemption.ts
@@ -12,7 +12,7 @@ function ctEqual(a: Uint8Array, b: Uint8Array): boolean {
 
 export function base64UrlToUint8Array(base64Url: string): Uint8Array {
 	// Convert URL escaped characters to regular base64 string
-	const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+	const base64 = base64Url.replace(/^"/, '').replace(/"$/, '').replace(/-/g, '+').replace(/_/g, '/');
 
 	return Uint8Array.from(atob(base64), c => c.charCodeAt(0));
 }

--- a/src/redemption.ts
+++ b/src/redemption.ts
@@ -56,6 +56,7 @@ export async function verifyToken(authenticator: string, tokenKey: CryptoKey, co
 			signatureInput
 		);
 	} catch (err) {
+		console.log("Token verification failed", err)
 		return false;
 	}
 }


### PR DESCRIPTION
the PrivacyToken spec [includes quotes][1] around the base64 encoded data. to decode and validate the token we need to remove the quotes. without removing the quotes, `atob` raises an exception and the exception gets silently swallowed and the verify function incorrectly returns `false` for valid tokens.

[1]: https://ietf-wg-privacypass.github.io/base-drafts/draft-ietf-privacypass-auth-scheme.html#section-2.2.2
